### PR TITLE
Added contails_tol function

### DIFF
--- a/structures/Space.h
+++ b/structures/Space.h
@@ -192,6 +192,14 @@ public:
 				&& -box.axis2_length <= b && b <= box.axis2_length
 				&& -box.axis3_length <= c && c <= box.axis3_length;
 	}
+	
+        // Check if point is contained by box with certain tolerence
+        template <typename T, typename T2>
+        static inline bool contains_tol(const OrientedBox<T>& b, const Vector3D<T2>& v, double tol = -1e-14){
+            return v.x - b.lesser_corner.x >= tol && b.greater_corner.x - v.x >= tol
+                    && v.y - b.lesser_corner.y >= tol && b.greater_corner.y - v.y >= tol
+                    && v.z - b.lesser_corner.z >= tol && b.greater_corner.z - v.z >= tol;
+        }
 
 	/// Do two oriented boxes intersect
 	template <typename T, typename T2>


### PR DESCRIPTION
contains_tol tests to see if a point is inside a box within a certain tolerance. This is essential if you are finding line-plane intersection points as it allows for you to eliminate the issues of a point on the box's face not being detected as contained due to floating point errors. The default tolerance is set to 1e-14 for this reason.