### PR TITLE
Allow TipsyWriter class to be constructed on a memory buffer.

### DIFF
--- a/structures/TipsyReader.h
+++ b/structures/TipsyReader.h
@@ -298,6 +298,23 @@ class TipsyWriter {
 	    ok = true;
             set_sizes();
 	}
+
+	/// Write to a buffer
+        TipsyWriter(void *buffer, size_t size, header &parh,
+                    bool pnative=false, bool _bDP = false, bool _bDV = false)
+	    : native(pnative), ok(false), h(parh), bDoublePos(_bDP),
+            bDoubleVel(_bDV) {
+            tipsyFp = fmemopen(buffer, size, "rb+");
+	    if(tipsyFp == NULL) {
+		ok = false;
+		assert(0);
+		return;
+		}
+	    if(!native)
+		xdrstdio_create(&xdrs, tipsyFp, XDR_ENCODE);
+	    ok = true;
+            set_sizes();
+	}
 	
 	~TipsyWriter() {
 	    if(tipsyFp == NULL)


### PR DESCRIPTION
This will allow the class to work with the charm CkIO module.
