### PR TITLE
Tipsy::header: replace operator|(PUPer,) with PUPbytes().

### DIFF
--- a/structures/TipsyReader.h
+++ b/structures/TipsyReader.h
@@ -348,6 +348,10 @@ class TipsyWriter {
 #include "pup.h"
 #include "charm++.h"
 
+PUPbytes(Tipsy::header);
+/* Having trouble using this in a parameter marshalling context in a
+   .ci file.  PUPbytes appears to work.
+
 inline void operator|(PUP::er& p, Tipsy::header& h) {
 	p | h.time;
 	p | h.nbodies;
@@ -356,6 +360,7 @@ inline void operator|(PUP::er& p, Tipsy::header& h) {
 	p | h.ndark;
 	p | h.nstar;
 }
+*/
 
 class CkOStream;
 


### PR DESCRIPTION
Having a Tipsy::header type as an entry method parameter in newer versions of charm seems not to compile.  Switching from operator|(PUPer, Tipsy::header) to PUPbytes(Tipsy::header) appears to fix it.
